### PR TITLE
Add allureId

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,22 @@ test('validation message appears, when email field is skipped', () => {
 })
 ```
 
+### :bug: AllureId
+
+Test Case ID in Allure.
+
+Example:
+
+```TS
+test('validation message appears, when email field is skipped', () => {
+  /**
+   * @allureId 92066
+   */
+
+  ...
+})
+```
+
 ## 👩‍🎓 Advanced
 
 ### 🎛 Global Allure API
@@ -330,4 +346,9 @@ allure.tag(name: string): void;
  * Add a custom label to the report of the current test.
  */
 allure.label(name: string, value: string): void;
+
+/**
+ * Add Test Case ID in Allure.
+ */
+allure.allureId(id: string, index?: number): void;
 ```

--- a/src/allure-reporter.ts
+++ b/src/allure-reporter.ts
@@ -395,7 +395,7 @@ export default class AllureReporter {
 		}
 
 		if (subSuite) {
-			currentTest.addLabel(LabelName.SUB_SUITE, subSuite.testResultContainer.name);
+			currentTest.addLabel(LabelName.SUB_SUITE, subSuite.name);
 		}
 
 		return currentTest;

--- a/src/allure-reporter.ts
+++ b/src/allure-reporter.ts
@@ -370,6 +370,9 @@ export default class AllureReporter {
 					currentTest.addLabel(labelName, value);
 					currentTest.addLabel('epic', value);
 					break;
+				case 'allureId':
+					currentTest.addLabel(LabelName.AS_ID, value);
+					break;
 				default:
 					currentTest.addLabel(labelName, value);
 					break;

--- a/src/jest-allure-interface.ts
+++ b/src/jest-allure-interface.ts
@@ -209,4 +209,8 @@ export default class JestAllureInterface extends Allure {
 		// @ts-expect-error (2322)
 		return this.reporter.currentTest;
 	}
+
+	allureId(id: string, index?: number): void {
+		this.label(LabelName.AS_ID, id, index);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing! -->

### User facing changelog

- Add `allureId` (see [here](https://github.com/allure-framework/allure-java/blob/master/allure-java-commons/src/main/java/io/qameta/allure/AllureId.java) for more details).

### Additional details

I also fix compilation issue in cfa83aac65f4f6bbb1b0d6c81f5be3d2c1a33ee7. `subSuite` has type [AllureGroup](https://github.com/allure-framework/allure-js/blob/44db5df7026609270d6651402cbc0c99c2e873b4/packages/allure-js-commons/src/AllureGroup.ts) and `testResultContainer` is private filed, so we can't use them. But expression `testResultContainer.name` can be replaced by [name](https://github.com/allure-framework/allure-js/blob/44db5df7026609270d6651402cbc0c99c2e873b4/packages/allure-js-commons/src/AllureGroup.ts#L35-L37).

### PR Tasks

<!--
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable.
-->

- [ ] Have tests been added/updated?
- [x] If APIs were added/changed, did you add/update documentation?
